### PR TITLE
Cherry pick to fix build issues related to manifest

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,6 +1,6 @@
 MIT License
 
-Copyright (c) 2020 SmartRackTest
+Copyright (c) 2020 NI
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ Create a directory for your OE-Core setup to live in and clone the meta-informat
 ```
 $ mkdir ${HOME}/oe-core
 $ cd ${HOME}/oe-core
-$ repo init -u https://github.com/ni/smartracks-manifest.git -b $GITBRANCH -m smartracks-manifest.xml
+$ repo init -u https://github.com/ni/ateccgen2-manifest.git -b $GITBRANCH -m ateccgen2-manifest.xml
 $ repo sync
 ```
 Replace $GITBRANCH with the branch name that you would like to sync the manifest from, e.g. `main`
@@ -34,5 +34,5 @@ $ . export
 
 Build the image:
 ```
-$ bitbake smartracks-minimal-image
+$ bitbake ateccgen2-minimal-image
 ```

--- a/ateccgen2-manifest.xml
+++ b/ateccgen2-manifest.xml
@@ -71,8 +71,8 @@
   <!-- https://github.com/mendersoftware/meta-mender-community/commit/91122992c85cb18a0daffcde76b6c59116e723b9 -->
   <project name="meta-mender-community" path="layers/meta-mender-community" remote="mender" revision="91122992c85cb18a0daffcde76b6c59116e723b9" upstream="dunfell"/>
     
-  <!-- meta-smartrack: Branch main -->
-  <project name="meta-smartracks.git" path="layers/meta-smartracks" remote="ni" revision="main" upstream="main">
+  <!-- meta-ateccgen2: Branch main -->
+  <project name="meta-ateccgen2.git" path="layers/meta-ateccgen2" remote="ni" revision="main" upstream="main">
     <copyfile dest="export" src="buildconf/export"/>
   </project>
 </manifest>

--- a/stub.yml
+++ b/stub.yml
@@ -1,6 +1,6 @@
 # Stub pipeline
-# Updates the TriggeringPipeline variable in SmartRacksPipelineVariables group.
-# After execution of this pipeline is finished, rcu-image-ci-pipeline.yml located in smatracks-script should be executed.
+# Updates the TriggeringPipeline variable in AteCoreConfigGen2PipelineVariables group.
+# After execution of this pipeline is finished, rcu-image-ci-pipeline.yml located in ateccgen2-script should be executed.
 
 variables:
   - group: AteCoreConfigGen2PipelineVariables
@@ -17,7 +17,7 @@ steps:
 - script: echo Triggering rcu-image-ci-pipeline!
 - powershell: |
     $url = "https://dev.azure.com/ni/DevCentral/_apis/distributedtask/variablegroups/303?api-version=5.0-preview.1"
-    $json = '{"id":2,"type":"Vsts","name":"AteCoreConfigGen2PipelineVariables","variables":{"TriggeringPipeline":{"isSecret":false,"value":"smartracks-manifest"},"CommitMessage":{"isSecret":false,"value":"$(Build.SourceVersionMessage)"}}}'
+    $json = '{"id":2,"type":"Vsts","name":"AteCoreConfigGen2PipelineVariables","variables":{"TriggeringPipeline":{"isSecret":false,"value":"ateccgen2-manifest"},"CommitMessage":{"isSecret":false,"value":"$(Build.SourceVersionMessage)"}}}'
     $pipeline = Invoke-RestMethod -Uri $url -Method Put -Body $json -ContentType "application/json" -Headers @{
         Authorization = "Bearer $env:SYSTEM_ACCESSTOKEN"
     }


### PR DESCRIPTION
Recent branch change from release/23.0.1f to release/23.0.1 resulted in some missing file name changes which allow the build to work correctly. This PR cherry picks from https://github.com/ni/ateccgen2-manifest/commit/f57ceff811af4141b0771b6edf0bb930ae65cb41 to reintroduce the proper filename changes to resolve build issues.